### PR TITLE
Code change to create a new file if file passed in argument doesnt exist

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/daviddecoding/kilo-go
 
 go 1.21.6
 
-require (
-	github.com/pkg/term v1.1.0 // indirect
-	golang.org/x/sys v0.18.0 // indirect
-	golang.org/x/term v0.18.0 // indirect
-)
+require golang.org/x/term v0.18.0
+
+require golang.org/x/sys v0.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,3 @@
-github.com/pkg/term v1.1.0 h1:xIAAdCMh3QIAy+5FrE8Ad8XoDhEU4ufwbaSozViP9kk=
-github.com/pkg/term v1.1.0/go.mod h1:E25nymQcrSllhX42Ok8MRm1+hyBdHY0dCeiKZ9jpNGw=
-golang.org/x/sys v0.0.0-20200909081042-eff7692f9009 h1:W0lCpv29Hv0UaM1LXb9QlBHLNP8UFfcKjblhVCWftOM=
-golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
 golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.18.0 h1:FcHjZXDMxI8mM3nwhX9HlKop4C0YQvCVCdwYl2wOtE8=

--- a/kilo.go
+++ b/kilo.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -530,6 +531,16 @@ func editorFind() {
 func editorOpen(filepath string) {
 	file, err := os.Open(filepath)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			//Create a new file with given filepath
+			file, err = os.Create(filepath)
+			if err != nil {
+				die(err.Error())
+			}
+			defer file.Close()
+			editorConfig.fileName = filepath
+			return
+		}
 		die(err.Error())
 	}
 	defer file.Close()

--- a/kilo.go
+++ b/kilo.go
@@ -529,23 +529,19 @@ func editorFind() {
 }
 
 func editorOpen(filepath string) {
+	editorConfig.fileName = filepath
+	_, err := os.Stat(filepath)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			die(err.Error())
+		}
+		return
+	}
 	file, err := os.Open(filepath)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			//Create a new file with given filepath
-			file, err = os.Create(filepath)
-			if err != nil {
-				die(err.Error())
-			}
-			defer file.Close()
-			editorConfig.fileName = filepath
-			return
-		}
 		die(err.Error())
 	}
 	defer file.Close()
-
-	editorConfig.fileName = filepath
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		editorConfig.fileBuffer.append(scanner.Text())


### PR DESCRIPTION
Currently, kilo-go doesnt work with files which dont already exist (which the original kilo editor does). If we try to open kilo-go with a new file, we see the message "no such file or directory" printed on the terminal. This small change is to ensure that if there isnt an existing file, then we create one and run the editor with it.

I also ran `go mod tidy` which updated go.mod and go.sum files. 

